### PR TITLE
Improve robustness of particle size scripts

### DIFF
--- a/processAllSize.py
+++ b/processAllSize.py
@@ -1,19 +1,29 @@
 import os
 import glob
 import subprocess
+import argparse
 
-# ディレクトリのパスを指定
-directory = "/Users/yasu-air/Dropbox/yhLab/KS24-16/cam1"  # 処理するディレクトリを指定してください
 
-# `directory` 内のすべてのCSVファイルを取得
-pkl_files = glob.glob(os.path.join(directory, "*.pkl"))
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Process all pickle files in a directory")
+    parser.add_argument(
+        "-d",
+        "--directory",
+        required=True,
+        help="Directory containing .pkl files",
+    )
+    args = parser.parse_args()
 
-# すべてのpklファイルに対して `saveParticleSize.py` を実行
-for pkl_file in pkl_files:
-    try:
-        print(f"Processing file: {pkl_file}")
-        # saveParticleSize.py を実行
-        subprocess.run(["python3", "saveParticleSize.py", "-i", pkl_file], check=False)
-        print(f"Finished processing: {pkl_file}")
-    except subprocess.CalledProcessError as e:
-        print(f"Error processing {pkl_file}: {e}")
+    pkl_files = glob.glob(os.path.join(args.directory, "*.pkl"))
+
+    for pkl_file in pkl_files:
+        try:
+            print(f"Processing file: {pkl_file}")
+            subprocess.run(["python3", "saveParticleSize.py", "-i", pkl_file], check=False)
+            print(f"Finished processing: {pkl_file}")
+        except subprocess.CalledProcessError as e:
+            print(f"Error processing {pkl_file}: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_projection.py
+++ b/tests/test_projection.py
@@ -1,0 +1,24 @@
+import numpy as np
+import pytest
+
+from saveParticleSize import project_parallel_to_view_vector
+
+
+def test_project_parallel_zero_vector():
+    points = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    view = np.array([0.0, 0.0, 0.0])
+    with pytest.warns(UserWarning):
+        proj = project_parallel_to_view_vector(points, view)
+    expected = points.copy()
+    expected[:, 2] = 0
+    np.testing.assert_allclose(proj, expected)
+
+
+def test_project_parallel_zero_z_component():
+    points = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    view = np.array([1.0, 0.0, 0.0])
+    with pytest.warns(UserWarning):
+        proj = project_parallel_to_view_vector(points, view)
+    expected = points.copy()
+    expected[:, 2] = 0
+    np.testing.assert_allclose(proj, expected)


### PR DESCRIPTION
## Summary
- add guard against zero view vectors in `project_parallel_to_view_vector`
- refactor `saveParticleSize.py` into reusable functions
- allow directory to be specified on command line for batch processing
- provide unit tests for projection edge cases

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy pytest` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_685caa6e95588323b72d298153a82cd7